### PR TITLE
T5 Tensor Parallelism

### DIFF
--- a/examples/offline_inference_enc_dec.py
+++ b/examples/offline_inference_enc_dec.py
@@ -57,7 +57,7 @@ if torch.cuda.is_available():
 native_outputs = model.generate(input_ids).cpu()
 
 # vLLM test
-for num_model_shards in [1, 2, 3]:
+for num_model_shards in [1, 4]:
     model = LLM(hf_model_id,
                 enforce_eager=True,
                 dtype=dtype,

--- a/examples/offline_inference_enc_dec.py
+++ b/examples/offline_inference_enc_dec.py
@@ -8,11 +8,14 @@ Scenarios:
 
 Output: for several prompts, compare native PyTorch & vLLM prompt completions
 '''
+import ray
+import gc
 import os
 import warnings
 import torch
 from vllm import LLM, SamplingParams
 from transformers import T5Tokenizer, T5ForConditionalGeneration
+from vllm.model_executor.parallel_utils.parallel_state import destroy_model_parallel
 
 os.environ["CUDA_VISIBLE_DEVICES"] = "0, 1, 2, 3"
 
@@ -54,32 +57,38 @@ if torch.cuda.is_available():
 native_outputs = model.generate(input_ids).cpu()
 
 # vLLM test
-model = LLM(
-    hf_model_id,
-    enforce_eager=True,
-    dtype=dtype,
-    gpu_memory_utilization=0.5,
-    # tensor_parallel_size=
-    # 1 -> correctness
-    # 2 -> first tokens are correct, but the rest are not
-    # 4 -> weird behavior on relative_attention_bias sharding
-    tensor_parallel_size=2)
+for num_model_shards in [1, 2, 3]:
+    model = LLM(hf_model_id,
+                enforce_eager=True,
+                dtype=dtype,
+                gpu_memory_utilization=0.5,
+                tensor_parallel_size=num_model_shards)
 
-sampling_params = SamplingParams(max_tokens=100, temperature=0)
+    sampling_params = SamplingParams(max_tokens=100, temperature=0)
 
-vllm_outputs = model.generate(
-    prompts,
-    sampling_params=sampling_params,
-)
-
-# Print native & vLLM outputs
-i = 0
-for native_output, vllm_output in zip(native_outputs, vllm_outputs):
-    prompt = prompts[i]  # Get the corresponding prompt for this output
-    native_generated_text = tokenizer.decode(
-        native_output, skip_special_tokens=True)  # Decode the generated text
-    vllm_generated_text = vllm_output.outputs[0].text
-    print(
-        f"Prompt: {prompt!r}, Native PyTorch generated text: {native_generated_text!r}, vLLM generated text: {vllm_generated_text!r}"
+    vllm_outputs = model.generate(
+        prompts,
+        sampling_params=sampling_params,
     )
-    i += 1
+
+    # Print native & vLLM outputs
+    i = 0
+    for native_output, vllm_output in zip(native_outputs, vllm_outputs):
+        prompt = prompts[i]  # Get the corresponding prompt for this output
+        native_generated_text = tokenizer.decode(
+            native_output,
+            skip_special_tokens=True)  # Decode the generated text
+        vllm_generated_text = vllm_output.outputs[0].text
+        print(
+            f"Num model shards: {num_model_shards}, Prompt: {prompt!r}, Native PyTorch generated text: {native_generated_text!r}, vLLM generated text: {vllm_generated_text!r}"
+        )
+        i += 1
+
+    # Delete the llm object and free the memory
+    destroy_model_parallel()
+    del model
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.distributed.destroy_process_group()
+    # close ray session
+    ray.shutdown()

--- a/vllm/model_executor/models/t5.py
+++ b/vllm/model_executor/models/t5.py
@@ -25,6 +25,7 @@ import torch
 from torch import nn
 from transformers import T5Config
 
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.input_metadata import InputMetadata
 from vllm.model_executor.layers.activation import get_act_fn
 from vllm.model_executor.layers.enc_dec_attention import (
@@ -39,12 +40,11 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.sampler import Sampler
 from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size, )
+    get_tensor_model_parallel_world_size, get_tensor_model_parallel_rank)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator,
+                                              load_tensor_parallel_weights)
 
 KVCache = Tuple[torch.Tensor, torch.Tensor]
 
@@ -152,16 +152,19 @@ class T5Attention(nn.Module):
         )
         assert total_num_heads % tensor_model_parallel_world_size == 0
         self.n_heads = total_num_heads // tensor_model_parallel_world_size
-        self.inner_dim = self.n_heads * self.key_value_proj_dim
 
-        self.q = ColumnParallelLinear(self.d_model, self.inner_dim, bias=False)
-        self.k = ColumnParallelLinear(self.d_model, self.inner_dim, bias=False)
-        self.v = ColumnParallelLinear(self.d_model, self.inner_dim, bias=False)
-        self.o = RowParallelLinear(self.inner_dim, self.d_model, bias=False)
+        self.q = ColumnParallelLinear(self.d_model, self.d_model, bias=False)
+        self.k = ColumnParallelLinear(self.d_model, self.d_model, bias=False)
+        self.v = ColumnParallelLinear(self.d_model, self.d_model, bias=False)
+        self.o = RowParallelLinear(self.d_model, self.d_model, bias=False)
 
         if has_relative_attention_bias:
-            self.relative_attention_bias = nn.Embedding(
-                self.relative_attention_num_buckets, self.n_heads)
+            if tensor_model_parallel_world_size > 1:
+                self.relative_attention_bias = VocabParallelEmbedding(
+                    self.relative_attention_num_buckets, total_num_heads)
+            else:
+                self.relative_attention_bias = nn.Embedding(
+                    self.relative_attention_num_buckets, total_num_heads)
 
         self.is_cross = is_cross
         if self.is_decoder:
@@ -519,7 +522,7 @@ class T5ForConditionalGeneration(nn.Module):
         self.config = config
         self.model_dim = config.d_model
 
-        self.shared = nn.Embedding(config.vocab_size, config.d_model)
+        self.shared = VocabParallelEmbedding(config.vocab_size, config.d_model)
 
         encoder_config = copy.deepcopy(config)
         encoder_config.is_decoder = False
@@ -575,6 +578,14 @@ class T5ForConditionalGeneration(nn.Module):
         load_format: str = "auto",
         revision: Optional[str] = None,
     ):
+        column_parallel_weight_names = [
+            "k.weight", "v.weight", "q.weight", "wi_0.weight", "wi.weight",
+            "shared.weight"
+        ]
+        row_parallel_weight_names = ["o.weight"]
+
+        parallel_weight_names = column_parallel_weight_names + row_parallel_weight_names
+
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, load_format, revision):
@@ -583,9 +594,23 @@ class T5ForConditionalGeneration(nn.Module):
 
             assert name in params_dict, f"{name} not in params_dict"
             param = params_dict[name]
-            assert param.shape == loaded_weight.shape, (
-                f"{name} shape mismatch between model and checkpoint: "
-                f"{param.shape} != {loaded_weight.shape}")
+            if any(_name in name for _name in parallel_weight_names):
+                load_tensor_parallel_weights(
+                    param,
+                    loaded_weight,
+                    name,
+                    column_parallel_weight_names=[
+                        "k.weight", "v.weight", "q.weight", "wi_0.weight",
+                        "wi.weight", "shared.weight"
+                    ],
+                    row_parallel_weight_names=["o.weight"],
+                    tensor_model_parallel_rank=get_tensor_model_parallel_rank(
+                    ))
+                continue
+
+            if param.shape != loaded_weight.shape:
+                print(f"{name} shape mismatch between model and checkpoint: "
+                      f"{param.shape} != {loaded_weight.shape}")
             weight_loader = getattr(param, "weight_loader",
                                     default_weight_loader)
             weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/t5.py
+++ b/vllm/model_executor/models/t5.py
@@ -84,24 +84,11 @@ class T5DenseActDense(nn.Module):
         self.wi = ColumnParallelLinear(config.d_model, config.d_ff, bias=False)
         self.wo = RowParallelLinear(config.d_ff, config.d_model, bias=False)
         self.act = get_act_fn(config.dense_act_fn)
-        # for debugging
-        self.expected_d_ff = config.d_ff // get_tensor_model_parallel_world_size(
-        )
-        self.d_model = config.d_model
 
     def forward(self, hidden_states):
-        # hidden_states comes in unsharded
-        # hidden_states.shape -> (bsz, seq_len, d_model)
-        assert hidden_states.shape[-1] == self.d_model
-
-        #### This sequence of operations is sharded ####
         hidden_states, _ = self.wi(hidden_states)
-        assert hidden_states.shape[-1] == self.expected_d_ff
         hidden_states = self.act(hidden_states)
-        assert hidden_states.shape[-1] == self.expected_d_ff
         hidden_states, _ = self.wo(hidden_states)
-        ###############################################
-        assert hidden_states.shape[-1] == self.d_model  # unsharded
 
         return hidden_states
 
@@ -173,11 +160,6 @@ class T5Attention(nn.Module):
         self.o = RowParallelLinear(self.d_model, self.d_model, bias=False)
 
         if has_relative_attention_bias:
-            # sharded attn_bias
-            # note: attn_bias is probably not a linear function of
-            # the input and needs more than just a context of the
-            # sharded part of the input. Also, padding of the vocabulary
-            # messes up the sharding logic
             self.relative_attention_bias = nn.Embedding(
                 self.relative_attention_num_buckets, self.n_heads)
 
@@ -276,13 +258,8 @@ class T5Attention(nn.Module):
         input_metadata: InputMetadata,
         encoder_hidden_states: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        # unshared hidden_states
-        assert hidden_states.shape[-1] == self.d_model
-        q, _ = self.q(hidden_states)
 
-        # sharded query i.e
-        # q.shape -> (bsz, seq_len, n_heads_per_shard * kv_dim)
-        assert q.shape[-1] == self.key_value_proj_dim * self.n_heads
+        q, _ = self.q(hidden_states)
 
         batch_size = hidden_states.shape[0]
         seq_len = hidden_states.shape[1]
@@ -297,10 +274,6 @@ class T5Attention(nn.Module):
             # Encoder self attention, no cache operations
             k, _ = self.k(hidden_states)
             v, _ = self.v(hidden_states)
-            # sharded k,v
-            # k.shape, v.shape -> (bsz, seq_len, n_heads_per_shard * kv_dim)
-            assert k.shape[-1] == self.key_value_proj_dim * self.n_heads
-            assert v.shape[-1] == self.key_value_proj_dim * self.n_heads
 
             if input_metadata.attn_bias is None:
                 input_metadata.attn_bias = self.compute_bias(
@@ -318,10 +291,6 @@ class T5Attention(nn.Module):
             # Decoder self attention
             k, _ = self.k(hidden_states)
             v, _ = self.v(hidden_states)
-            # sharded k,v
-            # k.shape, v.shape -> (bsz, seq_len, n_heads_per_shard * kv_dim)
-            assert k.shape[-1] == self.key_value_proj_dim * self.n_heads
-            assert v.shape[-1] == self.key_value_proj_dim * self.n_heads
 
             if input_metadata.attn_bias is None:
                 position_bias = self.compute_bias(
@@ -350,15 +319,8 @@ class T5Attention(nn.Module):
             else:
                 attn_output = self.attn(q, None, None, key_cache, value_cache,
                                         input_metadata)
-        # attn output should remain sharded
-        # attn_output.shape -> (bsz, seq_len, n_heads_per_shard * kv_dim)
-        assert attn_output.shape[-1] == self.key_value_proj_dim * self.n_heads
 
         attn_output, _ = self.o(attn_output)
-
-        # the self.o layer introduces all_reduce
-        # attn_output.shape -> (bsz, seq_len, d_model)
-        assert attn_output.shape[-1] == self.d_model
         return attn_output
 
 
@@ -558,8 +520,6 @@ class T5ForConditionalGeneration(nn.Module):
         self.config = config
         self.model_dim = config.d_model
 
-        # the embeddings can be safely shared between models
-        # nn.Embedding -> VocabParallelEmbedding
         self.shared = VocabParallelEmbedding(config.vocab_size, config.d_model)
 
         encoder_config = copy.deepcopy(config)
@@ -617,8 +577,8 @@ class T5ForConditionalGeneration(nn.Module):
         revision: Optional[str] = None,
     ):
 
-        # some weights are sharded across tensor model parallel dimensions
-        # we need to load them in a special way
+        # weight names that correspond to the loaded_weights
+        # that may need to be sharded in the column parallel fashion
         column_parallel_weight_names = [
             "k.weight",
             "v.weight",
@@ -627,12 +587,24 @@ class T5ForConditionalGeneration(nn.Module):
             "wi.weight",
             "shared.weight",
         ]
+        # ...and in the row parallel fashion
         row_parallel_weight_names = [
             "o.weight",
+        ]
+
+        # weight names for the relative position embeddings
+        # since computation of embeddings happens on each model shard separately
+        # (right between qkv projection and attention computation), we need to either:
+        # - load the full weight matrix (if no sharding, i.e. tensor_parallel = 1)
+        # - load the smaller chunk of the weight matrix (if sharding). The weight matrix
+        #   will be reduced across the last dimension (quasi row_parallel) to make sure
+        # that the shapes match
+        relative_attention_weight_names = [
             "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
             "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"
         ]
 
+        row_parallel_weight_names += relative_attention_weight_names
         parallel_weight_names = column_parallel_weight_names + row_parallel_weight_names
 
         params_dict = dict(self.named_parameters(remove_duplicate=False))
@@ -640,9 +612,6 @@ class T5ForConditionalGeneration(nn.Module):
                 model_name_or_path, cache_dir, load_format, revision):
             if "EncDecAttention.relative_attention_bias" in name:
                 continue
-
-            if name == "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight":
-                pass
 
             assert name in params_dict, f"{name} not in params_dict"
             param = params_dict[name]
@@ -658,8 +627,9 @@ class T5ForConditionalGeneration(nn.Module):
                 continue
 
             if param.shape != loaded_weight.shape:
-                print(f"{name} shape mismatch between model and checkpoint: "
-                      f"{param.shape} != {loaded_weight.shape}")
+                raise ValueError(
+                    f"{name} shape mismatch between model and checkpoint: "
+                    f"{param.shape} != {loaded_weight.shape}")
             weight_loader = getattr(param, "weight_loader",
                                     default_weight_loader)
             weight_loader(param, loaded_weight)

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -261,6 +261,34 @@ def hf_model_weights_iterator(
             torch.cuda.empty_cache()
 
 
+def load_tensor_parallel_weights(
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    param_name: str,
+    column_parallel_weight_names: List[str],
+    row_parallel_weight_names: List[str],
+    tensor_model_parallel_rank: int,
+) -> None:
+    for p in column_parallel_weight_names:
+        if p in param_name:
+            shard_size = param.shape[0]
+            start_idx = tensor_model_parallel_rank * shard_size
+            end_idx = (tensor_model_parallel_rank + 1) * shard_size
+            loaded_weight = loaded_weight[start_idx:end_idx]
+            break
+    for p in row_parallel_weight_names:
+        if p in param_name:
+            shard_size = param.shape[1]
+            start_idx = tensor_model_parallel_rank * shard_size
+            end_idx = (tensor_model_parallel_rank + 1) * shard_size
+            loaded_weight = loaded_weight[:, start_idx:end_idx]
+            break
+    assert param.shape == loaded_weight.shape, (
+        f"{param_name} shape mismatch between model and checkpoint: "
+        f"{param.shape} != {loaded_weight.shape}")
+    param.data.copy_(loaded_weight)
+
+
 def convert_pyslice_to_tensor(x: Any) -> torch.Tensor:
     """convert PySafeSlice object from safetensors to torch.Tensor
 


### PR DESCRIPTION
## Feature Description

The original PR was incorrectly implementing tensor parallelism for the T5 model. This PR adds the missing feature.

## Details

The goal is to ensure that the "model parallel" wrapper classes (`ColumnParallelLinear`, `RowParallelLinear`)  around typical transformers operation work correctly, as described in the original paper: https://arxiv.org/pdf/1909.08053.pdf. 

This PR makes sure that we are:
- parallelizing the atomic operations of the transformer architecture (`MLP` and `Attention` blocks are distributed across GPUs)
- correctly initializing `ColumnParallelLinear` and `RowParallelLinear` modules in  the `Attention` module (the modules take care for us of calculating the correct sharded tensor dimensions - this PR takes advantage of it)
- swapping the token embedding layer module from `nn.Embedding` (non-parallelizable) to `VocabParallelEmbedding`. This allows for the parallelization of the embedding GEMM.
- correctly loaded the weights for the layers that need to be sharded across multiple GPUs. This means either:
a) taking an original checkpoint weight matrix, splitting it into `num_shards` parts, and then sending it off to the appropriate devices. E.g. assuming four shards and column-wise sharding, if the matrix is `[N, M`], we create four `[N/4, M`] shards and send them to four model copies.
b) for the relative positional embeddings, if sharding is enabled, we need to only load the small chunk of the original matrix, such that its dimensions match the dimensions of the sharded hidden dimension. 

## Testing

Made sure that the output of the model is correct not only for an unsharded model but also for the models distributed across two and four shards (see `examples/offline_inference_enc_dec.py`)